### PR TITLE
rt 75636: arcade VNC session should open in same window

### DIFF
--- a/arcade/arcade.js
+++ b/arcade/arcade.js
@@ -13,20 +13,37 @@ $(document).ready(function() {
 // #auth_modal is in _page_header.html
 // the other items are expected to be in index_en.md
 function setNotAuthenticated() {
-  $('#authen_modal').modal('show')
+
+  // parameters here prevent closing the modal by clicking on the background
+  // or using esc key
+  $('#authen_modal').modal({
+    backdrop: 'static',
+    keyboard: false
+  })
+
   $('.arcade-authenticated').addClass('d-none')
   $('.arcade-not-authenticated').removeClass('d-none')
 
   $('#arcade_login_button').click(function() {
     $('#authen_modal').modal('show')}
   )
+
+  // hide and disable the close button on the authentication
+  // modal because authentication
+  // is required for using this page
+  $('#authen_modal button.close').addClass('disabled')
+  $('#authen_modal button.close').addClass('d-none')
+
 }
 
 // ---------------- arcade.canfar.net ajax functions & response handlers ---------------
 
 function handleAjaxFail(message) {
   setProgressBar(false)
+  // Clear entire modal plus backdrop so they don't stack
   $('#infoModal').modal('hide')
+  $('body').removeClass('modal-open')
+  $('.modal-backdrop').remove()
   $('.session-failed').removeClass('d-none')
   $('.session-started').addClass('d-none')
   $('.session-starting').addClass('d-none')
@@ -116,6 +133,8 @@ function getSession() {
       true,
       false
   )
+  // page sits at this info modal forever in some cases, as is when the person is not logged in.
+  // ideally capturing the 'close' from the login prompt would be best.
 
   return new Promise(function (resolve, reject) {
     var request = new XMLHttpRequest()

--- a/arcade/arcade.js
+++ b/arcade/arcade.js
@@ -133,9 +133,7 @@ function getSession() {
       true,
       false
   )
-  // page sits at this info modal forever in some cases, as is when the person is not logged in.
-  // ideally capturing the 'close' from the login prompt would be best.
-
+  
   return new Promise(function (resolve, reject) {
     var request = new XMLHttpRequest()
 

--- a/arcade/arcade.js
+++ b/arcade/arcade.js
@@ -62,7 +62,7 @@ function forwardTo(sessionName) {
     $('.session-starting').addClass('d-none')
     $('.session-started').removeClass('d-none')
     setProgressBar('okay')
-    window.open(sessionName, '_blank')
+    window.open(sessionName, '_self')
   }
 }
 


### PR DESCRIPTION
- plus controlling login so auth modal can't be closed if user not logged in.