### PR TITLE
s2483, ta11619, 11566, change Group Management link on CANFAR splash …

### DIFF
--- a/_includes/_page_header.html
+++ b/_includes/_page_header.html
@@ -108,6 +108,7 @@
 <script type="text/javascript" src="/cadcJS/javascript/org.opencadc.js"></script>
 <script type="text/javascript" src="/cadcJS/javascript/cadc.util.js"></script>
 <script type="text/javascript" src="/cadcJS/javascript/cadc.uri.js"></script>
+<script type="text/javascript" src="/canfar/javascript/cadc.redirect.util.js"></script>
 
 {% comment %} <div class="card text-white bg-warning">
   <div class="card-header"></div>

--- a/_layouts/splash.md
+++ b/_layouts/splash.md
@@ -32,8 +32,8 @@ layout: default
               </div>
             </div>
             <div class="mx-1 col">
-              <a href="/gmui" class="text-secondary">
-                <i class="fas fa-users service-link" data-toggle="tooltip" data-placement="top" title="Manage your CANFAR groups"></i>
+              <a href="" id="gmui_link" class="text-secondary">
+                <i class="fas fa-users service-link" data-toggle="tooltip" data-placement="top" title="Manage your CADC groups"></i>
               </a>
               <div>
                 <span>Group Management</span>
@@ -143,3 +143,11 @@ layout: default
   </footer>
   {% include _page_footer.html %}
 </div>
+<script>
+  $(document).ready(function() {
+    // Change the user-related menu items to point to
+    // URLs provided via /reg/applications
+    var redirectUtil = new ca.nrc.cadc.RedirectUtil()
+    redirectUtil.setHrefToUri(ca.nrc.cadc.accountURI.gmui, ['gmui_link'])
+  })
+</script>

--- a/_layouts/splash.md
+++ b/_layouts/splash.md
@@ -32,7 +32,7 @@ layout: default
               </div>
             </div>
             <div class="mx-1 col">
-              <a href="" id="gmui_link" class="text-secondary">
+              <a href="" target="_blank" id="gmui_link" class="text-secondary">
                 <i class="fas fa-users service-link" data-toggle="tooltip" data-placement="top" title="Manage your CADC groups"></i>
               </a>
               <div>

--- a/docs/group_management_en.md
+++ b/docs/group_management_en.md
@@ -7,13 +7,13 @@ permalink: /en/docs/group_management/
 ---
 
 
-The Group Management system is shared between CADC and CANFAR. This system provides the ability to limit access to particular archive and VOSpace datasets to particular groups of users.
+The Group Management system is a CADC service providing the ability to limit access to particular archive and VOSpace datasets to particular groups of CADC users.
 
 ## Group Management Tasks
 
 ### Creating a new group
 
-* Go to the [Group Management](https://www.canfar.net/canfar/groups) page and click the **Create Group** button
+* Go to the [Group Management](https://www.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/en/groups/) page and click the **Create Group** button
 * Fill in the dialog.  Adding a description can help keep you group names organized.
 * Click **Create**
 
@@ -21,7 +21,7 @@ The Group Management system is shared between CADC and CANFAR. This system provi
 
 To add a CADC users to a group to allow them access privileges associated with that group.
 
-* Go to the [Group Management](https://www.canfar.net/canfar/groups) page and find the desired group or create a new one.  Note that the the text boxes at the top of the table listing all the groups you are in can provide text based pattern filtering on the table contents.
+* Go to the [Group Management](https://www.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/en/groups/) page and find the desired group or create a new one.  Note that the the text boxes at the top of the table listing all the groups you are in can provide text based pattern filtering on the table contents.
 * Click the **View** link in the 'Members' column.
 * Type the name of the user you want to add to the group in the textbox at the bottom of the dialogue.  <em>If no textbox appears then you do not have permission to add members to this group.
 * Once you have selected the member you want to add, click the **Add member** button.
@@ -40,7 +40,7 @@ Group owners and group administrators may add and remove CADC users group the gr
 
 ### Groups of Groups
 
-The CADC/CANFAR [Group Management](https://www.canfar.net/canfar/groups) system allows you to add groups as members of other groups.  This can be a useful aid in efficient management of groups.  For example, you might create a group that is allowed to have write access to a VOSpace and another group that is allowed to have read access.  You can then add the 'write' group to the 'read' group so that any files that the 'read' group is given access to the 'write' group will automatically also have read access to. Where ever the term 'CADC Users' is used in the description of management task below, a Group Name could be substituted.
+The CADC/CANFAR [Group Management](https://www.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/en/groups/) system allows you to add groups as members of other groups.  This can be a useful aid in efficient management of groups.  For example, you might create a group that is allowed to have write access to a VOSpace and another group that is allowed to have read access.  You can then add the 'write' group to the 'read' group so that any files that the 'read' group is given access to the 'write' group will automatically also have read access to. Where ever the term 'CADC Users' is used in the description of management task below, a Group Name could be substituted.
 
 ## VOSpace Groups
 
@@ -50,7 +50,7 @@ Any user can create a new group, provided that the group name is unique in the C
 
 To assign privileged access to a directory of file within VOSpace the users must do the following:
 
-* Create a group with the CANFAR [Group Management](https://www.canfar.net/canfar/groups) system
+* Create a group with the CANFAR [Group Management](https://www.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/en/groups/) system
 * Add CADC/CANFAR users to that group
 * Assign that group READ or READ/WRITE access to the VOSpace file or directory
 
@@ -63,4 +63,4 @@ For each Program/Run ID within a telescope data collection a special group with 
 
 ### Granting Data Access
 
-The PI of a particular program can use the [Group Management](https://www.canfar.net/canfar/groups) page to view/edit the CADC users who are in the group, providing access to team members during the proprietary period.
+The PI of a particular program can use the [Group Management](https://www.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/en/groups/) page to view/edit the CADC users who are in the group, providing access to team members during the proprietary period.

--- a/docs/group_management_en.md
+++ b/docs/group_management_en.md
@@ -22,17 +22,19 @@ The Group Management system is a CADC service providing the ability to limit acc
 To add a CADC users to a group to allow them access privileges associated with that group.
 
 * Go to the [Group Management](https://www.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/en/groups/) page and find the desired group or create a new one.  Note that the the text boxes at the top of the table listing all the groups you are in can provide text based pattern filtering on the table contents.
-* Click the **View** link in the 'Members' column.
-* Type the name of the user you want to add to the group in the textbox at the bottom of the dialogue.  <em>If no textbox appears then you do not have permission to add members to this group.
-* Once you have selected the member you want to add, click the **Add member** button.
-* Add additional members if needed
-* Click the **Done** botton when you have finished adding members.
+* Click the **View** link in the 'Members' column. A modal dialog will be displayed with a list of current group members. The bottom of the panel may have input boxes to enter user and group names. <em>If no textboxes appear then you do not have permission to add members to this group.</em>
+* <em>To add a user to the group</em>: type the name of the user in the appropriate text box, then click **Add user**.   
+* <em>To add a group of users to the group</em>: start typing the name of the group in the appropriate text box, then select the group name from the autocomplete list provided. 
+Once you have selected the group you want to add, click the **Add group** button.
+* Add additional members if needed.
+* Click the **X** (close) button in the upper right of the dialog when you have finished adding members. You will be returned to the main list of your groups.
 
 ### Removing members from a group
 
-* Select the 'View' link in the Members column for the group of interest
-* Click the red **X** next to the name of the user you wish to remove
-* Click **Done**
+* Select the **View** link in the 'Members' column for the group of interest.
+* Click the red **X** next to the name of the user you wish to remove.
+* Click the **X** (close) button in the upper right of the dialog when you have finished adding members. You will be returned to the main list of your groups.
+
 
 ### Adding and Removing Administrators
 
@@ -40,18 +42,18 @@ Group owners and group administrators may add and remove CADC users group the gr
 
 ### Groups of Groups
 
-The CADC/CANFAR [Group Management](https://www.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/en/groups/) system allows you to add groups as members of other groups.  This can be a useful aid in efficient management of groups.  For example, you might create a group that is allowed to have write access to a VOSpace and another group that is allowed to have read access.  You can then add the 'write' group to the 'read' group so that any files that the 'read' group is given access to the 'write' group will automatically also have read access to. Where ever the term 'CADC Users' is used in the description of management task below, a Group Name could be substituted.
+The [Group Management](https://www.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/en/groups/) system allows you to add groups as members of other groups.  This can be a useful aid in efficient management of groups.  For example, you might create a group that is allowed to have write access to a VOSpace and another group that is allowed to have read access.  You can then add the 'write' group to the 'read' group so that any files that the 'read' group is given access to the 'write' group will automatically also have read access to. Where ever the term 'CADC User' is used in the description of management task below, a Group Name could be substituted.
 
 ## VOSpace Groups
 
-Any user can create a new group, provided that the group name is unique in the CADC/CANFAR group space.  These user created groups can have members added to them and those groups of users can be granted privilege access to particular files within VOSpace.
+Any user can create a new group, provided that the group name is unique in the CADC group space.  These user created groups can have members added to them and those groups of users can be granted privilege access to particular files within VOSpace.
 
 ### Granting VOSpace Access
 
 To assign privileged access to a directory of file within VOSpace the users must do the following:
 
-* Create a group with the CANFAR [Group Management](https://www.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/en/groups/) system
-* Add CADC/CANFAR users to that group
+* Create a CADC group with the [Group Management](https://www.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/en/groups/) system
+* Add CADC users to that group
 * Assign that group READ or READ/WRITE access to the VOSpace file or directory
 
 To assign READ or READ/WRITE access to a VOSpace file or directory use the VOSpace browser to select the object (checkbox next to the file or directory of interest) then click **Edit Permissions** and then click **Add Group** in the permissions dialog box.

--- a/docs/storage_en.md
+++ b/docs/storage_en.md
@@ -120,7 +120,7 @@ vmv vos:VOSPACE/foo/bar vos:VOSPACE/foo/bar2
 # provide group write permission on a VOSpace location (can be a directory or file). Up-to 4 groups can be given assigned permission.
 vchmod g+w vos:VOSPACE/foo/bar.txt 'GROUP1, GROUP2, GROUP3'
 
-# List of GROUP names is availabe from the [Group Managemnet Service](https://www.canfar.phys.uvic.ca/canfar/groups/)
+# List of GROUP names is availabe from the [Group Managemnet Service](https://www.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/en/groups/)
 {% endhighlight %}
 
 </div>


### PR DESCRIPTION
…page to point to cadc site /en/groups/. Update CANFAR documentation to point there as well.

wwebui/canfar-root s2483 branch has a change that this requires (adding a URI for gmui to the redirect javascript.) . 

The reg-applications.caps file in reg/cadc-registry-server already has the correct entry for GMUI, so it should be deployed already (and thus not need updating with this change.) 