### PR TITLE
CADC-9701: updates to Data Publication docs

### DIFF
--- a/docs/digital_object_identifiers_en.md
+++ b/docs/digital_object_identifiers_en.md
@@ -21,9 +21,9 @@ DOI will point to the published data on a permanent basis.
 
 #### Access
 There are 2 ways to access the DPS: 
-1.  From the CANFAR portal (select 'Data Publication' at https://www.canfar.net/)
+1.  From the CANFAR portal (select __Data Publication__ at [https://www.canfar.net/](https://www.canfar.net/))
 
-2. Through direct link - https://www.canfar.net/citation/
+2. Through direct link - [https://www.canfar.net/citation/](https://www.canfar.net/citation/)
 
 
 #### Account Requirements
@@ -45,9 +45,9 @@ In this step:
 - a DOI number is reserved for the data package associated with the paper - ie. 10.11570/20.0006
 - a Data Directory is made to house the data package. This is a VOSPace folder
 that can be accessed using the User Storage UI or using vos python tools - 
-ie. https://www.canfar.net/storage/list/AstroDataCitationDOI/CISTI.CANFAR/20.0006/data
+ie. [https://www.canfar.net/storage/list/AstroDataCitationDOI/CISTI.CANFAR/20.0006/data](https://www.canfar.net/storage/list/AstroDataCitationDOI/CISTI.CANFAR/20.0006/data)
 - a landing page is generated for the doi: 
-ie. https://www.canfar.net/citation/landing?doi=20.0006
+ie. [https://www.canfar.net/citation/landing?doi=20.0006](https://www.canfar.net/citation/landing?doi=20.0006)
 
 ##### 2. Upload the data package
 How this is done depends on both the size and volume of files that are
@@ -60,9 +60,9 @@ the data package. The author can share it with a journal editor or other referee
 The account is disabled after refereeing is complete.
 
 ##### 4. Publish DOI with Data Cite
-Though the CANFAR DPS, the DOI is 'Published' with DataCite and the Data
+Through the CANFAR DPS, the DOI is 'Published' with DataCite and the Data
 Directory is locked. Any further changes to the data package or the DOI 
-metadata (such as adding a Publication DOI) requires a request to CANFAR support.
+metadata (such as adding a Publication DOI) requires a request to [CANFAR support](mailto:support@canfar.net).
 
 Post-publication steps can include:
 - Addition of publication DOI to landing page
@@ -70,14 +70,14 @@ Post-publication steps can include:
 
 ### How to use the CANFAR Data Publication Service (DPS)
 #### Listing current DOIs
-The full list of CANFAR-hosted DOIs the currently authenticated user has access to can be found at https://www.canfar.net/citation/ 
+The full list of CANFAR-hosted DOIs the currently authenticated user has access to can be found at [https://www.canfar.net/citation/](https://www.canfar.net/citation/) 
 This page displays DOI details including status, name, title, links to landing page and data directory.
 
 From here a DOI can be requested, selected for viewing, editing or publishing, depending on the DOI status.
 
 #### Requesting a new DOI
 From either the DOI list or request page, a 'New' button will be available. Click this to generate a new DOI 
-request. The request form should be displayed at this link: https://www.canfar.net/citation/request.
+request. The request form can be found at [https://www.canfar.net/citation/request](https://www.canfar.net/citation/request).
 
 Minimum information needed:
 - First Author
@@ -95,7 +95,7 @@ and is displayed once the page refreshes.
 From the DOI list page, select the number or title to see more details on the 
 DOI request page. 
 
-ie. https://www.canfar.net/citation/request?doi=20.0016 (requires authentication)
+ie. [https://www.canfar.net/citation/request?doi=20.0016](https://www.canfar.net/citation/request?doi=20.0016) (requires authentication)
 
 Details on the page include:
 - DOI number
@@ -114,15 +114,15 @@ by an authenticated user.
 Modify any of the values in the form that are available, then press 'Update'. The new values
 are displayed when the page refreshes.
 
-If a DOI IS published, a request to edit it must be made through support@canfar.net.
+If a DOI is published, a request to edit it must be made through [CANFAR support](mailto:support@canfar.net).
 
 
 #### Viewing DOI landing page
 The landing page provides the outside world with all the pertinent information about your 
 journal paper and related data. It's the document DataCite links your DOI to.
 
-exmample: http://doi.org/10.11570/20.0016
-links to: https://www.canfar.net/citation/landing?doi=20.0016
+example: [http://doi.org/10.11570/20.0016](http://doi.org/10.11570/20.0016)<br>
+links to: [https://www.canfar.net/citation/landing?doi=20.0016](https://www.canfar.net/citation/landing?doi=20.0016)
 
 The page contains information about the paper, links to the published data and related publications.
 
@@ -136,27 +136,24 @@ shown and the data package is complete, press 'Publish' and the system will do t
 - complete registration of your DOI with DataCite
 - lock the Data Directory.
 
-Related publication information can be added manually after this step, through contacting support@canfar.net.
+Related publication information can be added manually after this step, by contacting [CANFAR support](mailto:support@canfar.net).
 
 
 #### Deleting Unpublished DOIs
-If for some reason a DOI is created in error, it can be deleted prior to publication from 
-the request page. In the upper right of the page, press the 'Delete' button. 
+A DOI request can be deleted prior to publication using the ‘Delete’ action on the request page. 
 
-NOTE: for PUBLISHED DOIs, no 'Delete' button is available.
+NOTE: for PUBLISHED DOIs, no 'Delete' action is available.
 
 
 ### DOI Data Package
-DPS provides a Data Directory for the data package to reside in. It's hosted by CANFAR in the Vault VOSpace impelmentation. 
+DPS provides a Data Directory for the data package to reside in. The Data Directory is hosted by CANFAR in the Vault VOSpace impelmentation. 
 A folder (literally called 'data') is created in the main folder for a DOI. The structure below that point is up to 
 the DOI owner. 
 
-example: https://www.canfar.net/storage/vault/list/AstroDataCitationDOI/CISTI.CANFAR/21.0002/data
-
-The amount of data that can be stored there depends on the quota for the authenticated user.
+example: [https://www.canfar.net/storage/vault/list/AstroDataCitationDOI/CISTI.CANFAR/21.0002/data](https://www.canfar.net/storage/vault/list/AstroDataCitationDOI/CISTI.CANFAR/21.0002/data)
 
 NOTE: after a DOI is published, this folder is locked and can no longer be modified without assistance
-from support@canfar.net. 
+from [CANFAR support](mailto:support@canfar.net).
 
 
 #### Content of the data package
@@ -169,12 +166,12 @@ There are two ways to upload a data package. Which method you use depends on the
 data being uploaded.
  
 - For a smaller number of small-sized files, the User Storage UI is a good choice. 
-See it's documentation here: https://www.canfar.net/en/docs/storage/ 
+Documentation: [User Storage documentation](https://www.canfar.net/en/docs/storage/) 
 
 - For very large files, or for large numbers of files, the Python vcp tools are a better choice.
-Full instructions for using vcp can also be found in the User Storage documentation, 
-under 'The vos Python module and command line client'
-: https://www.canfar.net/en/docs/storage/
+Full instructions for using vcp can also be found
+under 'The vos Python module and command line client' in the
+[User Storage documentation](https://www.canfar.net/en/docs/storage/) 
 
 
 #### Refereeing: Sharing the data package with the journal editor and referee
@@ -182,7 +179,7 @@ Sharing the data package with the science community enhances and supplements the
 Furthermore, evaluation and assessment of the data package by the journal editors and referees is an 
 additional enhancement to the value of data publication.
 
-Authors should contact support@canfar.net to obtain a user name and password for an account that can access (in readonly mode) 
+Authors should contact [CANFAR support](mailto:support@canfar.net) to obtain a user name and password for an account that can access (in readonly mode) 
 the folder hosting the data package. The author can share this account information with the journal editor. 
 The editor can then pass that account information on to the referee. 
 
@@ -194,7 +191,7 @@ The journal editor and referee may examine and approve the revisions or modifica
 #### Revising the Content of the data package
 
 The author retains the ability to modify the data package and may do so at any point prior to publishing their DOI.
-After publication, the DOI owner needs to contact support@canfar.net for assistance.
+After publication, the DOI owner needs to contact [CANFAR support](mailto:support@canfar.net) for assistance.
 
 
 ### Publishing (minting) the DOI
@@ -202,15 +199,14 @@ After publication, the DOI owner needs to contact support@canfar.net for assista
 Once the refereeing process is complete and the paper is accepted the author can use the Publish button to “mint” 
 (register the DOI with DataCite). This will lock the folder hosting the data package and the
 DOI information itself (author list, journal reference, etc.) so 
-that the author can no longer make changes. The data will be visible by the world using 
-the DOI. The data will be discoverable through the DataCite search interface (with very 
+that the author can no longer make changes. The data will be discoverable through the DataCite search interface (with very 
 limited discovery metadata).
 
 ### Revising and finalising publication and data package information
 
 The final step is to link the data package DOI with the journal DOI. This is not currently automated.
 
-The author should contact support@canfar.net to:
+The author should contact [CANFAR support](mailto:support@canfar.net) to:
 - include the journal paper DOI in the data package information 
 - update the journal reference (title, volume, page) 
 
@@ -220,7 +216,7 @@ journal editor to have it included in the journal paper.
 
 ### Need further assistance?
 
-Please contact support@canfar.net if you need any assistance. 
+Please contact [CANFAR support](mailto:support@canfar.net) if you need any assistance. 
 
 Comments and feedback from users is greatly valued.
 


### PR DESCRIPTION
Requests came through slack from JJ after his review:

"Looks great. Here are some minor edits to the documentation.  Please update and release!

- Item 4. the word ‘Though’ should be ‘Through’ 
- request to CANFAR support -> request to <CANFAR support>.  [ i.e. make this a link]
- Can the URLs given in the page be made active links?
- If a DOI IS published --> If a DOI is published
- through contacting support@canfar.net. --> by contacting  <CANFAR Support>
- If for some reason a DOI is created in error, it can be deleted prior to publication from the request page --> A DOI request can be deleted prior to publication using the ‘Delete’ action on the request page.
- It’s hosted by -> The Data Directory is hosted by
- Volume of data stored is not limited to user quote.  The quota is set on primary AstroDataCitation directory.  Delete the information explaining the quota.
- Don’t put the email address in the help pages, just say ‘CANFAR Support’ and make that work a link to the Support page.
- [DELETE this sentence] The data will be visible by the world using the DOI. (it’s just confusing)>"