### PR TITLE
CADC-10296: replace change password with reset password text in static content menus

### DIFF
--- a/_includes/_page_header.html
+++ b/_includes/_page_header.html
@@ -56,7 +56,7 @@
             <li>
                <a href=""
                  class="dropdown-item account_access_info"
-                 tabindex="3" title="Change password" id="changePassword" >Change password</a>
+                 tabindex="3" title="Reset password" id="changePassword" >Reset password</a>
             </li>
             <li>
               <a title="Obtain certificate" class="dropdown-item account_access_info"


### PR DESCRIPTION
Element id does not need to change, as there is javascript in place that will look for that id and add the correct URL to the menu. Best to leave that working.